### PR TITLE
Adds sesame-sail-nativerdf as dependency.

### DIFF
--- a/dspace-lod/dspace-lod-api/pom.xml
+++ b/dspace-lod/dspace-lod-api/pom.xml
@@ -115,6 +115,11 @@
            <artifactId>sesame-repository-manager</artifactId>
            <version>2.7.9</version>
        </dependency>
+       <dependency>
+           <groupId>org.openrdf.sesame</groupId>
+           <artifactId>sesame-sail-nativerdf</artifactId>
+           <version>2.7.9</version>
+       </dependency>
    
        <dependency>
            <artifactId>jtidy</artifactId>


### PR DESCRIPTION
Ant fresh_install failed cause spring was unable to find some classes.
Declairing sesame-sail-nativerdf as dependency fixes this bug.
