### PR TITLE
RDF viewer at /xmlui/data to get a context-path to load static resources

### DIFF
--- a/dspace-lod/dspace-lod-xmlui/src/main/webapp/static/lod/rdf2html.xsl
+++ b/dspace-lod/dspace-lod-xmlui/src/main/webapp/static/lod/rdf2html.xsl
@@ -24,6 +24,18 @@
 
     <xsl:output indent="yes"/>
 
+    <xsl:variable name="context-path">
+        <xsl:choose>
+            <xsl:when test="contains(//@rdf:about, '/handle')">
+                <!-- http://localhost:8080/xmlui/handle/123456789/1122, get string before /handle -->
+                <xsl:value-of select="substring-before(//@rdf:about, '/handle')"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="//@rdf:about"/>
+            </xsl:otherwise>
+        </xsl:choose>
+
+    </xsl:variable>
 
     <xsl:template match="/rdf:RDF">
         <html>
@@ -31,8 +43,16 @@
                 <title>
                     <xsl:value-of select="*[0]/@rdf:about"/>
                 </title>
-                <link rel="stylesheet" type="text/css" href="/static/lod/style.css" />
-                <link rel="stylesheet" type="text/css" href="/static/lod/metadata.css" />
+                <link rel="stylesheet" type="text/css">
+                    <xsl:attribute name="href">
+                        <xsl:value-of select="concat($context-path,'/static/lod/style.css')"/>
+                    </xsl:attribute>
+                </link>
+                <link rel="stylesheet" type="text/css">
+                    <xsl:attribute name="href">
+                        <xsl:value-of select="concat($context-path,'/static/lod/metadata.css')"/>
+                    </xsl:attribute>
+                </link>
 
                 <link rel="alternate" type="application/rdf+xml" href="?Accept=application/rdf+xml" title="This page in RDF (XML)" />
                 <link rel="alternate" type="text/turtle" href="?Accept=text/turtle" title="This page in RDF (Turtle)" />
@@ -40,7 +60,14 @@
             <body class="browser">
 
                 <div id="rdficon">
-                    <a href="?Accept=text/n3" title="RDF data"><img src="/static/lod/rdf_flyer.24.gif" alt="[RDF data]" /></a>
+                    <a href="?Accept=text/n3" title="RDF data">
+                        <img alt="[RDF data]">
+                            <xsl:attribute name="src">
+                                <xsl:value-of select="concat($context-path,'/static/lod/rdf_flyer.24.gif')"/>
+                            </xsl:attribute>
+                            <xsl:attribute name="title"><xsl:value-of select="$context-path"></xsl:value-of></xsl:attribute>
+                        </img>
+                    </a>
                 </div>
 
                 <div id="header">
@@ -50,8 +77,22 @@
                 </div>
 
                 <div class="section" style="line-height:30px">
-                    <strong><a href="/">Home</a></strong>
-                    <strong><a href="/data">Data</a></strong>
+                    <strong>
+                        <a>
+                            <xsl:attribute name="href">
+                                <xsl:value-of select="$context-path"/>
+                            </xsl:attribute>
+                            <xsl:text>Home</xsl:text>
+                        </a>
+                    </strong>
+                    <strong>
+                        <a>
+                            <xsl:attribute name="href">
+                                <xsl:value-of select="concat($context-path, '/data')"/>
+                            </xsl:attribute>
+                            <xsl:text>Data</xsl:text>
+                        </a>
+                    </strong>
                     <strong><a href="/sesame/repositories/dspace">SPARQL End-Point</a></strong>
                 </div>
 
@@ -79,12 +120,16 @@
 
     <xsl:template match="@rdf:about|@rdf:resource">
         <a>
-            <xsl:attribute name="href"><xsl:value-of select="concat('/data?subject=',.)"/></xsl:attribute>
+            <xsl:attribute name="href"><xsl:value-of select="concat($context-path, '/data?subject=', .)"/></xsl:attribute>
             <xsl:value-of select="."/>
         </a>
         <a>
             <xsl:attribute name="href"><xsl:value-of select="."/></xsl:attribute>
-            <img src="/static/lod/external.png"/>
+            <img>
+                <xsl:attribute name="src">
+                    <xsl:value-of select="concat($context-path,'/static/lod/external.png')"/>
+                </xsl:attribute>
+            </img>
         </a>
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
It seems that /xmlui/data has a hardcoded assumption that you are deploying xmlui to the ROOT context. So, I've added some code to the XSL to get it to try to figure it out. Tested on my localhost thus far.

Can't load static resources (before this commit)
![screen shot 2014-10-07 at 5 12 28 pm](https://cloud.githubusercontent.com/assets/58014/4550856/c96782bc-4e6a-11e4-8519-adeb7c908d0a.png)

Can load static resources (after this commit)
![screen shot 2014-10-07 at 5 12 55 pm](https://cloud.githubusercontent.com/assets/58014/4550862/db2a7c66-4e6a-11e4-8cbd-38c64a2104cc.png)
