### PR TITLE
Add link to scheme with contextpath from scheme manager

### DIFF
--- a/dspace-aac/aac-xmlui/src/main/java/org/dspace/app/xmlui/aspect/authority/scheme/ManageSchemeMain.java
+++ b/dspace-aac/aac-xmlui/src/main/java/org/dspace/app/xmlui/aspect/authority/scheme/ManageSchemeMain.java
@@ -250,7 +250,7 @@ public class ManageSchemeMain extends AbstractDSpaceTransformer
             //row.addCellContent(schemeID);
             if(isSystemAdmin){
                 Cell identifierCell = row.addCell();
-                identifierCell.addXref("/scheme/"+scheme.getID(), scheme.getName());
+                identifierCell.addXref(contextPath + "/scheme/"+scheme.getID(), scheme.getName());
                 identifierCell.addContent(" (" + scheme.getIdentifier().substring(0,8) + ")");
                 row.addCell().addContent(scheme.getCreated().toString());
                 Cell actionCell = row.addCell() ;


### PR DESCRIPTION
Manage Schemes Page: http://localhost:8080/xmlui/admin/scheme

Links to:
http://localhost:8080/scheme/1
http://localhost:8080/scheme/2

Code is missing `contextPath`, to make that
http://localhost:8080/xmlui/scheme/1
